### PR TITLE
Add fzf mappings for quick searching

### DIFF
--- a/nvim/init.vim
+++ b/nvim/init.vim
@@ -59,7 +59,7 @@ set relativenumber                " Show line numbers relative to current line.
 set ruler                         " Show cursor position.
 set scrolloff=10                  " Show N lines of context around the cursor.
 
-" Colorscheme 
+" Colorscheme
 colorscheme solarized
 set background=dark
 
@@ -136,8 +136,12 @@ nnoremap j gj
 nnoremap k gk
 
 nmap <c-p> :Files<cr>
+nnoremap <Leader>p :Fi <c-r><c-w><CR>
+vnoremap <leader>p y:Fi <c-r>"<CR>
+command! -bang -nargs=* Fi call fzf#vim#files('.', {'options':'--query '.shellescape(<q-args>)})
 nmap <c-o> :Buffers<cr>
 nmap <c-i> :Ag<cr>
+nnoremap <leader>i :Ag <c-r><c-w><CR>
 " Insert mode completion
 imap <c-x><c-f> <plug>(fzf-complete-path)
 imap <c-x><c-j> <plug>(fzf-complete-file-ag)
@@ -150,7 +154,6 @@ let g:UltiSnipsJumpBackwardTrigger="<c-k>"
 " When reading a buffer (after 1s), and when writing.
 call neomake#configure#automake('rw', 1000)
 let g:neomake_open_list = 2
-
 
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " Machine local


### PR DESCRIPTION
Hi! I'm doing this as part of Hacktoberfest (my first one ever!) https://hacktoberfest.digitalocean.com.

Hey so I've been wondering how I'm going to contribute, and if there is anything I've played around with a lot this year, it would be playing around with dotfiles. I noticed you use vim and also `fzf` which IMO are great tools and I've gone really fricken hard on these tools, trying to find the best way forward with them. (https://github.com/suessflorian/Tools/blob/master/init.vim#L37)

The biggest change I'd propose is given in line 144 - now you diverge slightly from me in the sense that you use Ag over Rg (https://github.com/BurntSushi/ripgrep) for reaching. Which means I can't propose my custom Rg script, but in similar vane, sometimes you very quickly want to find the occurrences of a word in your project with a quick swoop rather than beginning an Ag fzf wrapped search and manually entering it in.

The mapping itself may need tuning, but I really recommend it.

Hope this interests you!